### PR TITLE
Make able to download MNIST data automatically.

### DIFF
--- a/src/CSharp/CSharpExamples/AdversarialExampleGeneration.cs
+++ b/src/CSharp/CSharpExamples/AdversarialExampleGeneration.cs
@@ -80,23 +80,12 @@ namespace CSharpExamples
             }
 
             Console.WriteLine($"\tPreparing training and test data...");
-
-            var sourceDir = _dataLocation;
-            var targetDir = Path.Combine(_dataLocation, "test_data");
-
-            if (!Directory.Exists(targetDir)) {
-                Directory.CreateDirectory(targetDir);
-                Decompress.DecompressGZipFile(Path.Combine(sourceDir, "train-images-idx3-ubyte.gz"), targetDir);
-                Decompress.DecompressGZipFile(Path.Combine(sourceDir, "train-labels-idx1-ubyte.gz"), targetDir);
-                Decompress.DecompressGZipFile(Path.Combine(sourceDir, "t10k-images-idx3-ubyte.gz"), targetDir);
-                Decompress.DecompressGZipFile(Path.Combine(sourceDir, "t10k-labels-idx1-ubyte.gz"), targetDir);
-            }
-
+            
             TorchSharp.Examples.MNIST.Model model = null;
 
             var normImage = transforms.Normalize(new double[] { 0.1307 }, new double[] { 0.3081 }, device: (Device)device);
 
-            using (var test = new MNISTReader(targetDir, "t10k", _testBatchSize, device: device, transform: normImage)) {
+            using (var test = new MNISTReader(is_train: false, download: true, batch_size: _testBatchSize, device: device, transform: normImage)) {
 
                 var modelFile = dataset + ".model.bin";
 
@@ -106,7 +95,7 @@ namespace CSharpExamples
 
                     model = new TorchSharp.Examples.MNIST.Model("model", device);
 
-                    using (var train = new MNISTReader(targetDir, "train", _trainBatchSize, device: device, shuffle: true, transform: normImage)) {
+                    using (var train = new MNISTReader(is_train: true, download: true, batch_size: _trainBatchSize, device: device, shuffle: true, transform: normImage)) {
                         MNIST.TrainingLoop(dataset, timeout, (Device)device, model, train, test);
                     }
 

--- a/src/CSharp/CSharpExamples/MNIST.cs
+++ b/src/CSharp/CSharpExamples/MNIST.cs
@@ -57,23 +57,7 @@ namespace CSharpExamples
             Console.WriteLine($"\tRunning MNIST with {dataset} on {device.type.ToString()} for {epochs} epochs, terminating after {TimeSpan.FromSeconds(timeout)}.");
             Console.WriteLine();
 
-            var datasetPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory), "..", "Downloads", dataset);
-
             random.manual_seed(1);
-
-            var cwd = Environment.CurrentDirectory;
-
-
-            var sourceDir = datasetPath;
-            var targetDir = Path.Combine(datasetPath, "test_data");
-
-            if (!Directory.Exists(targetDir)) {
-                Directory.CreateDirectory(targetDir);
-                Decompress.DecompressGZipFile(Path.Combine(sourceDir, "train-images-idx3-ubyte.gz"), targetDir);
-                Decompress.DecompressGZipFile(Path.Combine(sourceDir, "train-labels-idx1-ubyte.gz"), targetDir);
-                Decompress.DecompressGZipFile(Path.Combine(sourceDir, "t10k-images-idx3-ubyte.gz"), targetDir);
-                Decompress.DecompressGZipFile(Path.Combine(sourceDir, "t10k-labels-idx1-ubyte.gz"), targetDir);
-            }
 
             if (device.type == DeviceType.CUDA) {
                 _trainBatchSize *= 4;
@@ -89,8 +73,8 @@ namespace CSharpExamples
             Console.WriteLine($"\tPreparing training and test data...");
             Console.WriteLine();
 
-            using (MNISTReader train = new MNISTReader(targetDir, "train", _trainBatchSize, device: device, shuffle: true, transform: normImage),
-                                test = new MNISTReader(targetDir, "t10k", _testBatchSize, device: device, transform: normImage)) {
+            using (MNISTReader train = new MNISTReader(download: true, is_train: true, batch_size: _trainBatchSize, device: device, shuffle: true, transform: normImage),
+                                test = new MNISTReader(download: true, is_train: false, batch_size: _testBatchSize, device: device, transform: normImage)) {
 
                 TrainingLoop(dataset, timeout, device, model, train, test);
             }


### PR DESCRIPTION
I think this will improve TorchSharp more easier for beginners.

In pytorch:
```py
mnist_train = dsets.MNIST(root='MNIST_data/', 
                          train=True, 
                          transform=transforms.ToTensor(), 
                          download=True)

mnist_test = dsets.MNIST(root='MNIST_data/', 
                         train=False,
                         transform=transforms.ToTensor(), 
                         download=True)
```
In my commit:
```cs
using (MNISTReader train = new MNISTReader(download: true, is_train: true, batch_size: _trainBatchSize, device: device, shuffle: true, transform: normImage),
    test = new MNISTReader(download: true, is_train: false, batch_size: _testBatchSize, device: device, transform: normImage)) {}
```