### PR TITLE
Remove reference to wrong code of conduct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ We have started work on tutorials, but they are not ready yet. They will mostly 
 
 # Contributing
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 There are two main things we would like help with:
 
 1. Adding completely new examples. File an issue and assign it to yourself, so we can track it.


### PR DESCRIPTION
See dotnet/org-policy-violations#7159

It is [recommended](https://github.com/dotnet/org-policy/blob/main/doc/PR15.md#mentions-in-readmemd-and-contributingmd) to remove mentions of the code of conduct in `README.md` or `CONTRIBUTING.md`.